### PR TITLE
修复XmlPullParserException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <fastjson.version>1.2.6</fastjson.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <jackson.version>2.8.3</jackson.version>
+        <kxml2.version>2.3.0</kxml2.version>
         <jetty-maven-plugin.version>9.3.0.RC0</jetty-maven-plugin.version>
     </properties>
 
@@ -83,6 +84,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
修复org.xmlpull.v1.XmlPullParserException: caused by: org.xmlpull.v1.XmlPullParserException: resource not found: /META-INF/services/org.xmlpull.v1.XmlPullParserFactory make sure that parser implementing XmlPull API is available问题